### PR TITLE
Change `discoverServices` to return `GattStatus`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ fun connect(context: Context, device: BluetoothDevice) = launch(UI) {
         // connect failed
     }
 
-    if (gatt.discoverServices().status != BluetoothGatt.GATT_SUCCESS) {
+    if (gatt.discoverServices() != BluetoothGatt.GATT_SUCCESS) {
         // discover services failed
     }
 

--- a/core/src/main/java/CoroutinesGatt.kt
+++ b/core/src/main/java/CoroutinesGatt.kt
@@ -26,7 +26,6 @@ import com.juul.able.experimental.messenger.OnCharacteristicWrite
 import com.juul.able.experimental.messenger.OnConnectionStateChange
 import com.juul.able.experimental.messenger.OnDescriptorWrite
 import com.juul.able.experimental.messenger.OnMtuChanged
-import com.juul.able.experimental.messenger.OnServicesDiscovered
 import kotlinx.coroutines.experimental.CompletableDeferred
 import kotlinx.coroutines.experimental.channels.BroadcastChannel
 import java.util.UUID
@@ -75,7 +74,7 @@ class CoroutinesGatt(
     /**
      * @throws [RemoteException] if underlying [BluetoothGatt.discoverServices] returns `false`.
      */
-    override suspend fun discoverServices(): OnServicesDiscovered {
+    override suspend fun discoverServices(): GattStatus {
         Able.debug { "discoverServices → send(DiscoverServices)" }
 
         val response = CompletableDeferred<Boolean>()
@@ -88,7 +87,7 @@ class CoroutinesGatt(
         }
 
         Able.verbose { "discoverServices → Waiting for BluetoothGattCallback" }
-        return messenger.callback.onServicesDiscovered.receive().also { (status) ->
+        return messenger.callback.onServicesDiscovered.receive().also { status ->
             Able.info { "discoverServices, status=${status.asGattStatusString()}" }
         }
     }

--- a/core/src/main/java/Gatt.kt
+++ b/core/src/main/java/Gatt.kt
@@ -18,7 +18,6 @@ import com.juul.able.experimental.messenger.OnCharacteristicWrite
 import com.juul.able.experimental.messenger.OnConnectionStateChange
 import com.juul.able.experimental.messenger.OnDescriptorWrite
 import com.juul.able.experimental.messenger.OnMtuChanged
-import com.juul.able.experimental.messenger.OnServicesDiscovered
 import kotlinx.coroutines.experimental.channels.BroadcastChannel
 import java.io.Closeable
 import java.util.UUID
@@ -71,7 +70,7 @@ interface Gatt : Closeable {
 
     suspend fun connect(): Boolean
     suspend fun disconnect(): Unit
-    suspend fun discoverServices(): OnServicesDiscovered
+    suspend fun discoverServices(): GattStatus
 
     suspend fun readCharacteristic(
         characteristic: BluetoothGattCharacteristic

--- a/core/src/main/java/messenger/GattCallback.kt
+++ b/core/src/main/java/messenger/GattCallback.kt
@@ -50,7 +50,7 @@ internal class GattCallback(config: GattCallbackConfig) : BluetoothGattCallback(
         BroadcastChannel<OnCharacteristicChanged>(config.onCharacteristicChangedCapacity)
 
     internal val onServicesDiscovered =
-        Channel<OnServicesDiscovered>(config.onServicesDiscoveredCapacity)
+        Channel<GattStatus>(config.onServicesDiscoveredCapacity)
     internal val onCharacteristicRead =
         Channel<OnCharacteristicRead>(config.onCharacteristicReadCapacity)
     internal val onCharacteristicWrite =
@@ -108,7 +108,7 @@ internal class GattCallback(config: GattCallbackConfig) : BluetoothGattCallback(
 
     override fun onServicesDiscovered(gatt: BluetoothGatt, status: GattStatus) {
         Able.verbose { "onServicesDiscovered → status = $status" }
-        if (!onServicesDiscovered.offer(OnServicesDiscovered(status))) {
+        if (!onServicesDiscovered.offer(status)) {
             Able.warn { "onServicesDiscovered → dropped" }
         }
         notifyGattReady()

--- a/core/src/main/java/messenger/Messages.kt
+++ b/core/src/main/java/messenger/Messages.kt
@@ -54,8 +54,6 @@ data class OnConnectionStateChange(
     val newState: GattState
 )
 
-data class OnServicesDiscovered(val status: GattStatus)
-
 data class OnCharacteristicRead(
     val characteristic: BluetoothGattCharacteristic,
     val value: ByteArray,

--- a/throw/src/main/java/Gatt.kt
+++ b/throw/src/main/java/Gatt.kt
@@ -24,7 +24,7 @@ suspend fun Gatt.connectOrThrow(): Unit {
  */
 suspend fun Gatt.discoverServicesOrThrow(): Unit {
     discoverServices()
-        .also { (status) ->
+        .also { status ->
             check(status == android.bluetooth.BluetoothGatt.GATT_SUCCESS) {
                 "Service discovery failed with gatt status $status."
             }


### PR DESCRIPTION
Was unnecessarily wrapped in a `OnServicesDiscovered` object that **only** held the `GattStatus`.

## API Change

| `Gatt` pre PR | `Gatt` post PR |
|-|-|
| <pre><code>suspend fun discoverServices(): GattStatus</code></pre> | <pre><code>suspend fun discoverServices(): OnServicesDiscovered</code></pre> |