### PR TITLE
Directly call `setCharacteristicNotification`

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ sealed class ConnectGattResult {
     characteristic: BluetoothGattCharacteristic,
     enable: Boolean
 ): Boolean</code></pre></td>
-<td><pre><code>suspend fun setCharacteristicNotification(
+<td><pre><code>fun setCharacteristicNotification(
     characteristic: BluetoothGattCharacteristic,
     enable: Boolean
-): Boolean</code><sup>3</sup></pre></td>
+): Boolean</code></pre></td>
 </tr>
 </table>
 

--- a/core/src/main/java/CoroutinesGatt.kt
+++ b/core/src/main/java/CoroutinesGatt.kt
@@ -13,7 +13,6 @@ import android.bluetooth.BluetoothGattService
 import android.bluetooth.BluetoothProfile.STATE_CONNECTED
 import android.bluetooth.BluetoothProfile.STATE_DISCONNECTED
 import android.os.RemoteException
-import com.juul.able.experimental.messenger.Message.CharacteristicNotification
 import com.juul.able.experimental.messenger.Message.DiscoverServices
 import com.juul.able.experimental.messenger.Message.ReadCharacteristic
 import com.juul.able.experimental.messenger.Message.RequestMtu
@@ -203,26 +202,12 @@ class CoroutinesGatt(
         }
     }
 
-    /**
-     * @throws [RemoteException] if underlying [BluetoothGatt.setCharacteristicNotification] returns `false`.
-     */
-    override suspend fun setCharacteristicNotification(
+    override fun setCharacteristicNotification(
         characteristic: BluetoothGattCharacteristic,
         enable: Boolean
     ): Boolean {
-        val response = CompletableDeferred<Boolean>()
-        messenger.send(CharacteristicNotification(characteristic, enable, response))
-
-        val uuid = characteristic.uuid
-        val call = "BluetoothGatt.setCharacteristicNotification(" +
-            "BluetoothGattCharacteristic[uuid=$uuid], enabled=$enable)"
-        Able.verbose { "requestMtu → Waiting for $call" }
-        if (!response.await()) {
-            throw RemoteException("$call returned false.")
-        }
-
-        Able.info { "setCharacteristicNotification $uuid enable=$enable" }
-        return true
+        Able.info { "setCharacteristicNotification ${characteristic.uuid} enable=$enable" }
+        return bluetoothGatt.setCharacteristicNotification(characteristic, enable)
     }
 }
 

--- a/core/src/main/java/Gatt.kt
+++ b/core/src/main/java/Gatt.kt
@@ -89,11 +89,10 @@ interface Gatt : Closeable {
 
     suspend fun requestMtu(mtu: Int): OnMtuChanged
 
-    suspend fun setCharacteristicNotification(
+    fun setCharacteristicNotification(
         characteristic: BluetoothGattCharacteristic,
         enable: Boolean
     ): Boolean
-
 }
 
 suspend fun Gatt.writeCharacteristic(

--- a/core/src/main/java/messenger/Messages.kt
+++ b/core/src/main/java/messenger/Messages.kt
@@ -36,12 +36,6 @@ internal sealed class Message {
         override val response: CompletableDeferred<Boolean>
     ) : Message()
 
-    internal data class CharacteristicNotification(
-        val characteristic: BluetoothGattCharacteristic,
-        val enable: Boolean,
-        override val response: CompletableDeferred<Boolean>
-    ) : Message()
-
     internal data class WriteDescriptor(
         val descriptor: BluetoothGattDescriptor,
         val value: ByteArray,

--- a/core/src/main/java/messenger/Messenger.kt
+++ b/core/src/main/java/messenger/Messenger.kt
@@ -6,7 +6,6 @@ package com.juul.able.experimental.messenger
 
 import android.bluetooth.BluetoothGatt
 import com.juul.able.experimental.Able
-import com.juul.able.experimental.messenger.Message.CharacteristicNotification
 import com.juul.able.experimental.messenger.Message.DiscoverServices
 import com.juul.able.experimental.messenger.Message.ReadCharacteristic
 import com.juul.able.experimental.messenger.Message.RequestMtu
@@ -35,15 +34,6 @@ class Messenger internal constructor(
                 is DiscoverServices -> bluetoothGatt.discoverServices()
                 is ReadCharacteristic -> bluetoothGatt.readCharacteristic(message.characteristic)
                 is RequestMtu -> bluetoothGatt.requestMtu(message.mtu)
-                is CharacteristicNotification ->
-                    bluetoothGatt.setCharacteristicNotification(
-                        message.characteristic,
-                        message.enable
-                    ).also {
-                        // We release the lock right away because `setCharacteristicNotification`
-                        // does not result in a `BluetoothGattCallback` method being invoked.
-                        callback.notifyGattReady()
-                    }
                 is WriteCharacteristic -> {
                     message.characteristic.value = message.value
                     message.characteristic.writeType = message.writeType

--- a/retry/src/main/java/Retry.kt
+++ b/retry/src/main/java/Retry.kt
@@ -186,25 +186,4 @@ class Retry(private val gatt: Gatt, timeoutDuration: Long, timeoutUnit: TimeUnit
             result
         }
     }
-
-    /**
-     * Sets (and retries if necessary) characteristic notification, connecting to [Gatt] as needed.
-     *
-     * @throws [TimeoutCancellationException] if timeout occurs.
-     * @throws [IllegalStateException] if [checkConnection] calls [Gatt.connect] and it returns `false`.
-     */
-    override suspend fun setCharacteristicNotification(
-        characteristic: BluetoothGattCharacteristic,
-        enable: Boolean
-    ): Boolean {
-        return withTimeoutLock(timeoutMillis) {
-            var result: Boolean
-            do {
-                checkConnection()
-                result = gatt.setCharacteristicNotification(characteristic, enable)
-            } while (!result && isEnabled)
-            result
-        }
-    }
-
 }


### PR DESCRIPTION
According to [Dave Smith] in the [Developing Bluetooth Smart Applications for Android Tutorial] YouTube video, we don't need to explicitly wait for the completion of the `setCharacteristicNotification` call. This behavior also agrees with the [`BluetoothGatt` source code] which does **not** have the following code block in `setCharacteristicNotification`:

```java
synchronized(mDeviceBusy) {
    if (mDeviceBusy) return false;
    mDeviceBusy = true;
}
```

Whereas the other calls that we explicitly wait for completion do adhere to the `mDeviceBusy` state.

[Dave Smith]: https://github.com/devunwired
[Developing Bluetooth Smart Applications for Android Tutorial]: https://youtu.be/x1y4tEHDwk0?t=20m10s
[`BluetoothGatt` source code]: https://android.googlesource.com/platform/frameworks/base/+/4dc66d3c582f05e72ea3b157883420f1ee07608c/core/java/android/bluetooth/BluetoothGatt.java#1389