### PR TITLE
Remove @Throws from String.toUuid extension function

### DIFF
--- a/core/src/main/java/Uuid.kt
+++ b/core/src/main/java/Uuid.kt
@@ -9,5 +9,4 @@ import java.util.UUID
 /**
  * @throw [IllegalArgumentException] if receiver does not conform to the string representation as described in [UUID.toString].
  */
-@Throws(IllegalArgumentException::class)
 fun String.toUuid(): UUID = UUID.fromString(this)


### PR DESCRIPTION
The underlying `UUID.fromString` method does not declare throwing `IllegalArgumentException` (as a checked exception) so it is unnecessary to mark the extension function.