### PR TITLE
Perform onConnectAction after assigning Gatt property

### DIFF
--- a/keep-alive/src/main/java/KeepAliveGatt.kt
+++ b/keep-alive/src/main/java/KeepAliveGatt.kt
@@ -173,8 +173,8 @@ class KeepAliveGatt internal constructor(
                             gatt.onCharacteristicChanged
                                 .onEach(_onCharacteristicChanged::send)
                                 .launchIn(this, start = UNDISPATCHED)
-                            onConnectAction?.invoke(gatt)
                             _gatt = gatt
+                            onConnectAction?.invoke(gatt)
                             _state.value = Connected
                         }
                     } finally {


### PR DESCRIPTION
A developer was unable to perform actions on their `Gatt` object if they used the reference returned by `keepAliveGatt` extension function. For example:

```
private val gatt: KeepAliveGatt = viewModelScope.keepAliveGatt(
    application,
    bluetoothDevice,
    disconnectTimeoutMillis = 5_000L
) {
    discoverServicesOrThrow()
    gatt.writeCharacteristicOrThrow(...) // <-- throws `NotReady` exception :(
}
```

By performing the `OnConnectAction` after the internal `Gatt` property assignment, the `KeepAliveGatt` has the needed reference and won't throw `NotReady` if a developer uses their own `Gatt` reference (provided from `keepAliveGatt` extension function).