### PR TITLE
Add GitHub action that validates Gradle wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2-beta
 
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
Integrates the official [Gradle wrapper validation GitHub Action](https://github.com/gradle/wrapper-validation-action).