### PR TITLE
Configure internal distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         --max-workers 2
         -PdisablePreDex
         -Pkotlin.incremental=false
+        -Pgithub.packages.username=${{ secrets.MOBILE_GITHUB_PACKAGES_USERNAME }}
+        -Pgithub.packages.password=${{ secrets.MOBILE_GITHUB_PACKAGES_PASSWORD }}
 
     steps:
       - name: Checkout
@@ -50,29 +52,8 @@ jobs:
         with:
           fail_ci_if_error: true
 
-      - name: Snapshot
-        if: startsWith(github.ref, 'refs/heads/') && endsWith(github.ref, '-SNAPSHOT')
-        run: >-
-          ./gradlew
-          $GRADLE_ARGS
-          --no-parallel
-          uploadArchives
-          -PVERSION_NAME="${GITHUB_REF/refs\/heads\//}"
-
-      - name: Keyring
-        if: startsWith(github.ref, 'refs/tags/')
-        run: mkdir -p ~/.gnupg && echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 --decode > ~/.gnupg/secring.gpg
-
       - name: Publish
         # https://github.community/t5/GitHub-Actions/Run-step-only-for-new-tags/m-p/32448/highlight/true#M1138
         if: startsWith(github.ref, 'refs/tags/')
         # https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
-        run: >-
-          ./gradlew
-          $GRADLE_ARGS
-          --no-parallel
-          uploadArchives
-          -PVERSION_NAME=${GITHUB_REF/refs\/tags\//}
-          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}"
-          -Psigning.password="${{ secrets.SIGNING_PASSWORD }}"
-          -Psigning.secretKeyRingFile="$HOME/.gnupg/secring.gpg"
+        run: ./gradlew $GRADLE_ARGS publish -Pversion=${GITHUB_REF/refs\/tags\//}

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'org.jetbrains.kotlin.android' version '1.3.70' apply false
     id 'org.jmailen.kotlinter' version '2.2.0' apply false
     id 'com.android.library' version '3.6.2' apply false
-    id 'com.vanniktech.maven.publish' version '0.11.1' apply false
+    id 'digital.wup.android-maven-publish' version '3.6.3' apply false
 
     // `jacoco-android` is incompatible with Gradle 6.x, fails with:
     // groovy.lang.GroovyRuntimeException: Cannot set the value of read-only property 'executionData'...
@@ -18,6 +18,17 @@ plugins {
     id 'com.hiya.jacoco-android' version '0.2' apply false
 
     id 'binary-compatibility-validator' version '0.2.3'
+}
+
+ext.publishUrl = {
+    def version = project.property("version")
+    if (version == null || version == "" || version == "unspecified") {
+        return ""
+    } else if (version ==~ /.+-dev-?\d+/) {
+        return "https://maven.pkg.github.com/juullabs/android-github-packages-dev"
+    } else {
+        throw GradleScriptException("Only publication of dev tags are allowed on internal branch.")
+    }
 }
 
 subprojects {
@@ -39,16 +50,14 @@ subprojects {
     }
 }
 
-// Prevent publishing if `VERSION_NAME` property is invalid (i.e. enforce `-PVERSION_NAME` command
-// line argument).
+// Prevent publishing if `version` property is not set (e.g. via `-Pversion` command line argument).
 gradle.taskGraph.whenReady { taskGraph ->
     taskGraph.getAllTasks().findAll { task ->
-        task.name.startsWith('installArchives') || task.name.startsWith('publishArchives')
+        task.name.startsWith('publish')
     }.forEach { task ->
         task.doFirst {
-            if (!project.hasProperty("VERSION_NAME") || project.findProperty("VERSION_NAME").startsWith("unspecified")) {
-                logger.error("VERSION_NAME=" + project.findProperty("VERSION_NAME"))
-                throw new GradleException("Unable to publish without valid VERSION_NAME property")
+            if (!project.hasProperty("version") || project.findProperty("version") == "unspecified") {
+                throw new GradleException("Unable to publish without version property")
             }
         }
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,8 +3,10 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'org.jmailen.kotlinter'
     id 'com.hiya.jacoco-android'
-    id 'com.vanniktech.maven.publish'
+    id 'digital.wup.android-maven-publish'
 }
+
+apply from: rootProject.file('gradle/publish.gradle')
 
 jacoco {
     toolVersion = "0.8.5"
@@ -16,10 +18,6 @@ jacocoAndroidUnitTestReport {
     xml.enabled true
 
     excludes += ['**/Debug*.*']
-}
-
-mavenPublish {
-    useLegacyMode = true
 }
 
 android {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,0 +1,35 @@
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+// https://help.github.com/en/github/managing-packages-with-github-packages/configuring-gradle-for-use-with-github-packages#example-using-gradle-groovy-for-multiple-packages-in-the-same-repository
+publishing {
+    repositories {
+        maven {
+            name = "github"
+
+            // Because upper case letters aren't supported, you must use lowercase letters for
+            // the repository owner even if the GitHub user or organization name contains
+            // uppercase letters.
+            //
+            // https://help.github.com/en/github/managing-packages-with-github-packages/configuring-gradle-for-use-with-github-packages#authenticating-with-a-personal-access-token
+            url = publishUrl()
+
+            credentials {
+                username = project.findProperty("github.packages.username")
+                password = project.findProperty("github.packages.password")
+            }
+        }
+    }
+
+    publications {
+        mavenAar(MavenPublication) {
+            from components.android
+            artifact sourcesJar
+
+            group = "com.juul.able"
+            version = project.property("version")
+        }
+    }
+}

--- a/keep-alive/build.gradle
+++ b/keep-alive/build.gradle
@@ -3,8 +3,10 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'org.jmailen.kotlinter'
     id 'com.hiya.jacoco-android'
-    id 'com.vanniktech.maven.publish'
+    id 'digital.wup.android-maven-publish'
 }
+
+apply from: rootProject.file('gradle/publish.gradle')
 
 jacoco {
     toolVersion = "0.8.5"
@@ -14,10 +16,6 @@ jacocoAndroidUnitTestReport {
     csv.enabled false
     html.enabled true
     xml.enabled true
-}
-
-mavenPublish {
-    useLegacyMode = true
 }
 
 android {

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -3,8 +3,10 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'org.jmailen.kotlinter'
     id 'com.hiya.jacoco-android'
-    id 'com.vanniktech.maven.publish'
+    id 'digital.wup.android-maven-publish'
 }
+
+apply from: rootProject.file('gradle/publish.gradle')
 
 jacoco {
     toolVersion = "0.8.5"
@@ -14,10 +16,6 @@ jacocoAndroidUnitTestReport {
     csv.enabled false
     html.enabled true
     xml.enabled true
-}
-
-mavenPublish {
-    useLegacyMode = true
 }
 
 android {

--- a/throw/build.gradle
+++ b/throw/build.gradle
@@ -3,8 +3,10 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'org.jmailen.kotlinter'
     id 'com.hiya.jacoco-android'
-    id 'com.vanniktech.maven.publish'
+    id 'digital.wup.android-maven-publish'
 }
+
+apply from: rootProject.file('gradle/publish.gradle')
 
 jacoco {
     toolVersion = "0.8.5"
@@ -14,10 +16,6 @@ jacocoAndroidUnitTestReport {
     csv.enabled false
     html.enabled true
     xml.enabled true
-}
-
-mavenPublish {
-    useLegacyMode = true
 }
 
 android {

--- a/timber-logger/build.gradle
+++ b/timber-logger/build.gradle
@@ -2,12 +2,10 @@ plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
     id 'org.jmailen.kotlinter'
-    id 'com.vanniktech.maven.publish'
+    id 'digital.wup.android-maven-publish'
 }
 
-mavenPublish {
-    useLegacyMode = true
-}
+apply from: rootProject.file('gradle/publish.gradle')
 
 android {
     compileSdkVersion versions.compileSdk


### PR DESCRIPTION
Configuring project for internal distribution ([android-github-packages-dev]) on `internal` branch.

This will allow for continued development using internal Coroutines publications (while waiting for `SharedFlow` to be officially released).

_Once `SharedFlow` is released, the `internal` branch will be merged into `develop` and ultimately deleted._

[android-github-packages-dev]: https://github.com/JuulLabs/android-github-packages-dev/packages