### PR TITLE
Use standard internal GitHub Packages repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext.publishUrl = {
     if (version == null || version == "" || version == "unspecified") {
         return ""
     } else if (version ==~ /.+-dev-?\d+/) {
-        return "https://maven.pkg.github.com/juullabs/android-github-packages-dev"
+        return "https://maven.pkg.github.com/juullabs/android-github-packages"
     } else {
         throw GradleScriptException("Only publication of dev tags are allowed on internal branch.")
     }


### PR DESCRIPTION
Discovered that GitHub [does not allow publication of artifacts with the same group ID to multiple repositories](https://github.community/t/github-packages-publish-to-another-repository/14537/3). Rather than introducing additional maven sources, we'll use the standard internal GitHub Packages repository.